### PR TITLE
[FIX] Pretendard 글꼴 미적용 수정

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import { RouterProvider } from 'react-router-dom';
 import router from './routes/Router';
+import './../public/fonts/font.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -56,7 +56,6 @@ const GlobalStyle = createGlobalStyle`
   body {
     margin: 0;
     padding: 0;
-    /* 폰트 */
     color: #FFFFFF;
     font-family: 'Pretendard';
 


### PR DESCRIPTION
## 구현 사항
### 문제 상황
![image](https://github.com/user-attachments/assets/5e7eb164-0941-41ee-853b-1738d04293f9)
### 해결 방법
현재 Pretendard 글꼴이 미적용 되고 있는 상태여서, 
main.tsx에 font.css를 import하여 수정하였습니다.
